### PR TITLE
Fix: Skip GPU tests in PkgEval

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,7 @@ module TestFoldsCUDA
 using Test
 
 const TEST_GPU =
-    lowercase(get(ENV, "JULIA_PKGEVAL", "false")) == "true" ||
+    lowercase(get(ENV, "JULIA_PKGEVAL", "false")) != "true" &&
     lowercase(get(ENV, "CUDAFOLDS_JL_TEST_GPU", "true")) == "true"
 
 @testset "$file" for file in sort([


### PR DESCRIPTION
The logic is wrong and not working: https://s3.amazonaws.com/julialang-reports/nanosoldier/pkgeval/by_date/2020-11/08/FoldsCUDA.1.6.0-DEV-6b7d530d97.log
