### PR TITLE
Update FLoops to the version that invokes init in loop

### DIFF
--- a/test/environments/jl15/Manifest.toml
+++ b/test/environments/jl15/Manifest.toml
@@ -152,8 +152,8 @@ version = "0.1.3"
 
 [[FLoops]]
 deps = ["Compat", "FLoopsBase", "JuliaVariables", "MLStyle", "Setfield", "Transducers"]
-git-tree-sha1 = "3c06ce549d470b5daffe2b2aa93f9cca12ed5a8a"
-repo-rev = "init-scope"
+git-tree-sha1 = "e48beffe4ab65f2f4ddc8d3e9fd2e9e3912fbba5"
+repo-rev = "master"
 repo-url = "https://github.com/JuliaFolds/FLoops.jl.git"
 uuid = "cc61a311-1640-44b5-9fba-1b764f453329"
 version = "0.1.9-DEV"

--- a/test/environments/jl15/Manifest.toml
+++ b/test/environments/jl15/Manifest.toml
@@ -134,11 +134,11 @@ version = "0.1.3"
 
 [[FLoops]]
 deps = ["Compat", "FLoopsBase", "JuliaVariables", "MLStyle", "Setfield", "Transducers"]
-git-tree-sha1 = "ede57016ce82455a99bd43e412d04a6c6d8d0915"
+git-tree-sha1 = "96b610049ab826fb8ba275686d3a254a8a131f1f"
 repo-rev = "init-scope"
 repo-url = "https://github.com/JuliaFolds/FLoops.jl.git"
 uuid = "cc61a311-1640-44b5-9fba-1b764f453329"
-version = "0.1.8-DEV"
+version = "0.1.9-DEV"
 
 [[FLoopsBase]]
 deps = ["ContextVariablesX"]

--- a/test/environments/jl15/Manifest.toml
+++ b/test/environments/jl15/Manifest.toml
@@ -152,7 +152,7 @@ version = "0.1.3"
 
 [[FLoops]]
 deps = ["Compat", "FLoopsBase", "JuliaVariables", "MLStyle", "Setfield", "Transducers"]
-git-tree-sha1 = "96b610049ab826fb8ba275686d3a254a8a131f1f"
+git-tree-sha1 = "3c06ce549d470b5daffe2b2aa93f9cca12ed5a8a"
 repo-rev = "init-scope"
 repo-url = "https://github.com/JuliaFolds/FLoops.jl.git"
 uuid = "cc61a311-1640-44b5-9fba-1b764f453329"

--- a/test/environments/jl15/Manifest.toml
+++ b/test/environments/jl15/Manifest.toml
@@ -134,11 +134,11 @@ version = "0.1.3"
 
 [[FLoops]]
 deps = ["Compat", "FLoopsBase", "JuliaVariables", "MLStyle", "Setfield", "Transducers"]
-git-tree-sha1 = "e38ee2e0fdb95053d26593f92ffaa8353b9ff53f"
-repo-rev = "master"
+git-tree-sha1 = "ede57016ce82455a99bd43e412d04a6c6d8d0915"
+repo-rev = "init-scope"
 repo-url = "https://github.com/JuliaFolds/FLoops.jl.git"
 uuid = "cc61a311-1640-44b5-9fba-1b764f453329"
-version = "0.1.6"
+version = "0.1.8-DEV"
 
 [[FLoopsBase]]
 deps = ["ContextVariablesX"]

--- a/test/environments/jl16/Manifest.toml
+++ b/test/environments/jl16/Manifest.toml
@@ -157,8 +157,8 @@ version = "0.1.3"
 
 [[FLoops]]
 deps = ["Compat", "FLoopsBase", "JuliaVariables", "MLStyle", "Setfield", "Transducers"]
-git-tree-sha1 = "c5ee09f593dc62c01993086e89035241abfcefb6"
-repo-rev = "master"
+git-tree-sha1 = "ede57016ce82455a99bd43e412d04a6c6d8d0915"
+repo-rev = "init-scope"
 repo-url = "https://github.com/JuliaFolds/FLoops.jl.git"
 uuid = "cc61a311-1640-44b5-9fba-1b764f453329"
 version = "0.1.8-DEV"

--- a/test/environments/jl16/Manifest.toml
+++ b/test/environments/jl16/Manifest.toml
@@ -157,8 +157,8 @@ version = "0.1.3"
 
 [[FLoops]]
 deps = ["Compat", "FLoopsBase", "JuliaVariables", "MLStyle", "Setfield", "Transducers"]
-git-tree-sha1 = "3c06ce549d470b5daffe2b2aa93f9cca12ed5a8a"
-repo-rev = "init-scope"
+git-tree-sha1 = "e48beffe4ab65f2f4ddc8d3e9fd2e9e3912fbba5"
+repo-rev = "master"
 repo-url = "https://github.com/JuliaFolds/FLoops.jl.git"
 uuid = "cc61a311-1640-44b5-9fba-1b764f453329"
 version = "0.1.9-DEV"

--- a/test/environments/jl16/Manifest.toml
+++ b/test/environments/jl16/Manifest.toml
@@ -157,11 +157,11 @@ version = "0.1.3"
 
 [[FLoops]]
 deps = ["Compat", "FLoopsBase", "JuliaVariables", "MLStyle", "Setfield", "Transducers"]
-git-tree-sha1 = "ede57016ce82455a99bd43e412d04a6c6d8d0915"
+git-tree-sha1 = "96b610049ab826fb8ba275686d3a254a8a131f1f"
 repo-rev = "init-scope"
 repo-url = "https://github.com/JuliaFolds/FLoops.jl.git"
 uuid = "cc61a311-1640-44b5-9fba-1b764f453329"
-version = "0.1.8-DEV"
+version = "0.1.9-DEV"
 
 [[FLoopsBase]]
 deps = ["ContextVariablesX"]

--- a/test/environments/jl16/Manifest.toml
+++ b/test/environments/jl16/Manifest.toml
@@ -157,7 +157,7 @@ version = "0.1.3"
 
 [[FLoops]]
 deps = ["Compat", "FLoopsBase", "JuliaVariables", "MLStyle", "Setfield", "Transducers"]
-git-tree-sha1 = "96b610049ab826fb8ba275686d3a254a8a131f1f"
+git-tree-sha1 = "3c06ce549d470b5daffe2b2aa93f9cca12ed5a8a"
 repo-rev = "init-scope"
 repo-url = "https://github.com/JuliaFolds/FLoops.jl.git"
 uuid = "cc61a311-1640-44b5-9fba-1b764f453329"


### PR DESCRIPTION
https://github.com/JuliaFolds/FLoops.jl/pull/73

## Commit Message
Update FLoops to the version that invokes init in loop (#52)

As of https://github.com/JuliaFolds/FLoops.jl/pull/73 the init clauses
are evaluated in loop body whenever required. This is not exercised in
FoldsCUDA.jl yet (supposedly). But, since FoldsCUDA.jl is one of the
most type-instability-sensitive FLoops.jl users, it makes sense to
start using/testing this new unreleased version.