### PR TITLE
Document that CUDAEx is the primary API

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ julia> Folds.reduce(TeeRF(min, max), xs, CUDAEx())
 julia> Folds.reduce(TeeRF(min, max), (2x for x in xs), CUDAEx())  # iterator comprehension works
 (-1.0f0, 4.0f0)
 
-julia> Folds.reduce(TeeRF(min, max), Map(x -> 2x), xs, CUDAEx())  # equivalent, using a transducer
+julia> Folds.reduce(TeeRF(min, max), Map(x -> 2x)(xs), CUDAEx())  # equivalent, using a transducer
 (-1.0f0, 4.0f0)
 ```
 

--- a/README.md
+++ b/README.md
@@ -15,14 +15,14 @@ parallel `for` loops that run on GPU.
 
 ## API
 
-* `foldx_cuda`: a GPU equivalent of parallel extended fold
-  [`Transducers.foldxt`](https://juliafolds.github.io/Transducers.jl/dev/reference/manual/#Transducers.foldxt).
-* `CUDAEx`: a parallel loop executor for FLoops.jl.
-
-See the documentation of
-[Transducers.jl](https://juliafolds.github.io/Transducers.jl/dev/) and
-[FLoops.jl](https://juliafolds.github.io/FLoops.jl/dev/) for more
-information.
+FoldsCUDA exports `CUDAEx`, a parallel loop
+[executor](https://juliafolds.github.io/Transducers.jl/dev/explanation/glossary/#glossary-executor).
+It can be used with the parallel `for` loop created with
+[`FLoops.@floop`](https://github.com/JuliaFolds/FLoops.jl),
+`Base`-like high-level parallel API in
+[Folds.jl](https://github.com/JuliaFolds/Folds.jl), and extensible
+transducers provided by
+[Transducers.jl](https://github.com/JuliaFolds/Transducers.jl).
 
 ## Examples
 
@@ -61,17 +61,17 @@ julia> imax  # the *first* position for the largest value
 ### `extrema` using `Transducers.TeeRF`
 
 ```julia
-julia> using Transducers
+julia> using Transducers, Folds
 
 julia> @allowscalar xs[300] = -0.5;
 
-julia> foldx_cuda(TeeRF(min, max), xs)
+julia> Folds.reduce(TeeRF(min, max), xs, CUDAEx())
 (-0.5f0, 2.0f0)
 
-julia> foldx_cuda(TeeRF(min, max), (2x for x in xs))  # iterator comprehension works
+julia> Folds.reduce(TeeRF(min, max), (2x for x in xs), CUDAEx())  # iterator comprehension works
 (-1.0f0, 4.0f0)
 
-julia> foldx_cuda(TeeRF(min, max), Map(x -> 2x), xs)  # equivalent, using a transducer
+julia> Folds.reduce(TeeRF(min, max), Map(x -> 2x), xs, CUDAEx())  # equivalent, using a transducer
 (-1.0f0, 4.0f0)
 ```
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -16,6 +16,7 @@ PAGES = [
         "In-place mutation with Referenceables.jl" =>
             "examples/inplace_mutation_with_referenceables.md",
     ],
+    hide("deprecated.md"),
 ]
 
 let example_dir = joinpath(dirname(@__DIR__), "examples")

--- a/docs/src/deprecated.md
+++ b/docs/src/deprecated.md
@@ -1,0 +1,6 @@
+# Deprecated API
+
+```@docs
+FoldsCUDA.foldx_cuda
+FoldsCUDA.transduce_cuda
+```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -6,7 +6,5 @@ CurrentModule = FoldsCUDA
 
 ```@docs
 FoldsCUDA
-FoldsCUDA.foldx_cuda
-FoldsCUDA.transduce_cuda
 FoldsCUDA.CUDAEx
 ```

--- a/src/FoldsCUDA.jl
+++ b/src/FoldsCUDA.jl
@@ -20,6 +20,7 @@ using Transducers:
     opcompose,
     reduced,
     start,
+    transduce,
     unreduced
 
 # TODO: Don't import internals from Transducers:

--- a/src/api.jl
+++ b/src/api.jl
@@ -14,7 +14,20 @@ foldx_cuda(op, xf, xs; kwargs...) = foldx_cuda(op, xf(xs); kwargs...)
 """
     CUDAEx()
 
-FLoops.jl executor implemented using CUDA.jl.
+A fold executor implemented using CUDA.jl.
+
+For more information about executor, see
+[Transducers.jl's glossary section](https://juliafolds.github.io/Transducers.jl/dev/explanation/glossary/#glossary-executor)
+and
+[FLoops.jl's API section](https://juliafolds.github.io/FLoops.jl/dev/reference/api/#executor).
+
+# Examples
+```jldoctest
+julia> using FoldsCUDA, Folds
+
+julia> Folds.sum(1:10, CUDAEx())
+55
+```
 """
 struct CUDAEx{K} <: Executor
     kwargs::K

--- a/src/api.jl
+++ b/src/api.jl
@@ -1,15 +1,22 @@
 """
     foldx_cuda(op[, xf], xs; init)
-    transduce_cuda(op[, xf], init, xs)
+    transduce_cuda(xf, op, init, xs)
 
 Extended fold backed up by CUDA.
 """
 (foldx_cuda, transduce_cuda)
 
-foldx_cuda(op, xs; init = DefaultInit, kwargs...) =
+function foldx_cuda(op, xs; init = DefaultInit, kwargs...)
+    Base.depwarn(
+        "`foldx_cuda(...)` is deprecated, use `Folds.reduce(..., CUDAEx())` instead.",
+        :foldx_cuda,
+    )
     Transducers.fold(op, xs, CUDAEx(; kwargs...); init = init)
+end
 
 foldx_cuda(op, xf, xs; kwargs...) = foldx_cuda(op, xf(xs); kwargs...)
+
+@deprecate transduce_cuda(args...; kwargs...) transduce(args..., CUDAEx(; kwargs...))
 
 """
     CUDAEx()
@@ -36,6 +43,6 @@ end
 popsimd(; simd = nothing, kwargs...) = kwargs
 
 Transducers.transduce(xf, rf::RF, init, xs, exc::CUDAEx) where {RF} =
-    transduce_cuda(xf, rf, init, xs; popsimd(; exc.kwargs...)...)
+    _transduce_cuda(xf, rf, init, xs; popsimd(; exc.kwargs...)...)
 
 Transducers.executor_type(::CuArray) = CUDAEx

--- a/src/kernels.jl
+++ b/src/kernels.jl
@@ -1,7 +1,7 @@
-transduce_cuda(xf::Transducer, op, init, xs; kwargs...) =
-    transduce_cuda(xf'(op), init, xs; kwargs...)
+_transduce_cuda(xf::Transducer, op, init, xs; kwargs...) =
+    _transduce_cuda(xf'(op), init, xs; kwargs...)
 
-function transduce_cuda(op, init, xs;)
+function _transduce_cuda(op, init, xs;)
     xf0, coll = extract_transducer(xs)
     if coll isa Iterators.Zip
         arrays = coll.is

--- a/test/FoldsCUDATests/src/test_deprecated.jl
+++ b/test/FoldsCUDATests/src/test_deprecated.jl
@@ -1,0 +1,27 @@
+module TestDeprecated
+
+using CUDA
+using FoldsCUDA
+using Test
+using Transducers
+
+function test_foldx_cuda()
+    result = Ref{Any}(nothing)
+    xs = CUDA.ones(3)
+    @test_deprecated result[] = foldx_cuda(TeeRF(min, max), xs)
+    if result[] !== nothing
+        @test result[] == (1, 1)
+    end
+end
+
+function test_transduce_cuda()
+    result = Ref{Any}(nothing)
+    xs = CUDA.ones(3)
+    @test_deprecated result[] =
+        transduce_cuda(Map(identity), TeeRF(min, max), (0.0f0, 2.0f0), xs)
+    if result[] !== nothing
+        @test result[] == (0, 2)
+    end
+end
+
+end  # module


### PR DESCRIPTION
## Commit Message
Document that CUDAEx is the primary API (#59)

Now that executors are moved to Transducers.jl, all API can be
accessed through CUDAEx.