### PR TITLE
Avoid downgrading CUDA.jl in test/environments/*/

### DIFF
--- a/test/environments/jl15/Project.toml
+++ b/test/environments/jl15/Project.toml
@@ -1,2 +1,3 @@
 [deps]
+FoldsCUDA = "6cd66ae4-5932-4b96-926d-e73e578e42cc"
 FoldsCUDATests = "d11caea5-3c98-4cd5-8a56-9589fe6662ee"

--- a/test/environments/jl16/Project.toml
+++ b/test/environments/jl16/Project.toml
@@ -1,2 +1,3 @@
 [deps]
+FoldsCUDA = "6cd66ae4-5932-4b96-926d-e73e578e42cc"
 FoldsCUDATests = "d11caea5-3c98-4cd5-8a56-9589fe6662ee"


### PR DESCRIPTION
It looks local Project.toml of a dev'ed package is used only if it is
included in deps.